### PR TITLE
fix: cf outputs not interpolated correctly

### DIFF
--- a/examples/interpolate-stack-vars.yml
+++ b/examples/interpolate-stack-vars.yml
@@ -2,15 +2,16 @@ service: my-service
 provider:
   name: ssm
 
-# stacks:
-#   - my-service-student-team
+stacks:
+  - custom-domains-${stage}
+  - auth-service-stateful-${stage}
 
 config:
   path: /${stage}/config
   defaults:
     DB_NAME: my-database
     DB_DB: my-db
-    # DB_ARN: arn-path-${TableName} # interpolated from custom-resources stack
+    DB_ARN: arn-path-${UserPoolId} # interpolated from custom-resources stack
 
 secret:
   path: /${stage}/secret

--- a/lib/services/cf/get-outputs.js
+++ b/lib/services/cf/get-outputs.js
@@ -33,13 +33,15 @@ const readCfOutputs = async ({ stackName }) => {
 
   log(chalk.cyan(`Stack outputs for: [${stackName}]`));
   log(chalk.gray(JSON.stringify(outputs, null, 2)));
+
+  return outputs;
 };
 
 const getOutputs = ({ stackNames = [] }) =>
-  Promise.all(stackNames, stackName =>
-    readCfOutputs({ stackName })
+  Promise.all(
+    stackNames.map(stackName => readCfOutputs({ stackName }))
   ).then(outputs =>
-    outputs.reduce((acc, output) => Object.assign(acc, output), {})
+    outputs.reduce((acc, output) => ({ ...acc, ...output }), {})
   );
 
 module.exports = {


### PR DESCRIPTION
## What did you implement:

Fix bug that was preventing `stacks` from being interpolated

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Provide verification config/commands/resources

