### PR TITLE
feat: new target option on export

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,11 @@ Usage: oprah export [options]
 Export of all of the configuration from the provider to a text json file
 
 Options:
-  -p, --path [path]  The location for the output secrets & configuration file
-                     (default: "/tmp/oprah-exports.json")
+  -p, --path [path]      The location for the output secrets & configuration file
+                         (default: "/tmp/oprah-exports.json" or ".env_oprah")
+  -t, --target [target]  The output target, available options are json|env
+                         (default:json)
+
   -h, --help         display help for command
 ```
 

--- a/bin/oprah
+++ b/bin/oprah
@@ -64,12 +64,17 @@ program
   )
   .option(
     '-p, --path [path]',
-    'The location for the output secrets & configuration file (default: "/tmp/oprah-exports.json")'
+    'The location for the output secrets & configuration file (default: "/tmp/oprah-exports.json" or ".env_oprah")'
   )
-  .action(({ path }) => {
+  .option(
+    '-t, --target [target]',
+    'The output target, available options are json|env (default:json)'
+  )
+  .action(({ path, target }) => {
     const { stage, config } = program.opts();
     oprahPromise = makeOprah({ stage, config }).export(
-      path || '/tmp/oprah-exports.json'
+      path || (target === 'env' ? '.env_oprah' : '/tmp/oprah-exports.json'),
+      target || 'json'
     );
   });
 

--- a/lib/commands/import-export/make-export.js
+++ b/lib/commands/import-export/make-export.js
@@ -4,7 +4,10 @@ const fs = require('fs');
 
 const { log } = require('../../utils/logger');
 
-const makeExport = ({ settingsService, parameterStore }) => async filePath => {
+const makeExport = ({ settingsService, parameterStore }) => async (
+  filePath,
+  target
+) => {
   const settings = await settingsService.getSettings();
 
   log(chalk.white(`Getting parameters..`));
@@ -26,7 +29,11 @@ const makeExport = ({ settingsService, parameterStore }) => async filePath => {
 
   return fs.writeFileSync(
     filePath,
-    JSON.stringify({ configs, secrets }, null, 2)
+    target === 'env'
+      ? `${Object.entries({ ...configs, ...secrets })
+        .map(([key, val]) => `${key.replace(/[^A-Za-z0-9]+/g, '_')}="${val}"`)
+        .join('\n')}\n`
+      : JSON.stringify({ configs, secrets }, null, 2)
   );
 };
 

--- a/lib/commands/import-export/make-export.js
+++ b/lib/commands/import-export/make-export.js
@@ -31,8 +31,8 @@ const makeExport = ({ settingsService, parameterStore }) => async (
     filePath,
     target === 'env'
       ? `${Object.entries({ ...configs, ...secrets })
-        .map(([key, val]) => `${key.replace(/[^A-Za-z0-9]+/g, '_')}="${val}"`)
-        .join('\n')}\n`
+          .map(([key, val]) => `${key.replace(/[^A-Za-z0-9]+/g, '_')}="${val}"`)
+          .join('\n')}\n`
       : JSON.stringify({ configs, secrets }, null, 2)
   );
 };

--- a/lib/commands/import-export/make-export.test.js
+++ b/lib/commands/import-export/make-export.test.js
@@ -10,7 +10,7 @@ describe('export', () => {
   const getSettingsMock = jest.fn();
   const getParametersMock = jest.fn();
 
-  beforeEach(() => {
+  beforeAll(() => {
     exportFunction = makeExport({
       settingsService: {
         getSettings: getSettingsMock
@@ -21,7 +21,7 @@ describe('export', () => {
     });
   });
 
-  it('should write to the specified file path', () => {
+  beforeEach(() => {
     getSettingsMock.mockImplementation(() =>
       Promise.resolve({
         secretParameters: ['path/to/secret1'],
@@ -40,7 +40,13 @@ describe('export', () => {
           'path/to/config1': 'config1Value'
         })
       );
+  });
 
+  afterEach(() => {
+    fs.writeFileSync.mockClear();
+  });
+
+  it('should write JSON version to the specified file path', () => {
     const filePath = './test.json';
 
     return exportFunction(filePath).then(() => {
@@ -56,6 +62,18 @@ describe('export', () => {
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         filePath,
         JSON.stringify(writeOutput, null, 2)
+      );
+    });
+  });
+
+  it('should write ENV version to the specified file path', () => {
+    const filePath = './.env.test';
+    const target = 'env';
+
+    return exportFunction(filePath, target).then(() => {
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        filePath,
+        'path_to_config1="config1Value"\npath_to_secret1="secret1Value"\n'
       );
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oprah",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Package to deploy parameters to AWS",
   "repository": "https://github.com/ACloudGuru/oprah.git",
   "author": "subash adhikari <subash.adhikari@acloud.guru>",
@@ -8,7 +8,8 @@
     "node": ">=12.14.0"
   },
   "contributors": [
-    "DevOps Team <devops@acloud.guru>"
+    "DevOps Team <devops@acloud.guru>",
+    "Jaepil Kim <jaepil.kim@acloud.guru>"
   ],
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## What did you implement:

While incorporating Oprah into Next.js driven frontend app, our team has identified the need to export the configs and secrets to an env file. Which would help with running the app locally and in the deployment process.

## How did you implement it:

Updated the `export` command to accept a new `target` option to switch between `json` (default) and `env`.

## How can we verify it:

`yarn oprah export -t env -p .env.local`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources

