### PR TITLE
fix: use -d to avoid option conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v5.2.1](2021-08-28)
+### Added
+- `-d, --deleting` option to delete orphan configurations or secrets
+
 ## [v5.2.0](2021-08-27)
-- Added `clean-up` command
-- Added `--clean-up` option to `run` command
+### Added
+- `clean-up` command
 
 ## [v5.0.0](2021-06-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v5.2.1](2021-08-28)
 ### Added
-- `-d, --deleting` option to delete orphan configurations or secrets
+- `run` command now supports `-d, --deleting` option to delete orphan configurations or secrets
 
 ## [v5.2.0](2021-08-27)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v5.2.1](2021-08-28)
 ### Added
-- `run` command now supports `-d, --deleting` option to delete orphan configurations or secrets
+- `run` command now supports `-r, --removing` option to remove orphan configurations or secrets
 
 ## [v5.2.0](2021-08-27)
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Options:
   -v, --variables [variables]  Variables used for config interpolation.
   -i, --interactive            Run on interactive mode
   -m, --missing                Only prompt missing values in interactive mode
-  -cu, --clean-up              Clean up orphan configs or secrets
+  -d, --deleting               Deleting orphan configs or secrets
   -h, --help                   display help for command
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Options:
   -v, --variables [variables]  Variables used for config interpolation.
   -i, --interactive            Run on interactive mode
   -m, --missing                Only prompt missing values in interactive mode
-  -d, --deleting               Deleting orphan configs or secrets
+  -r, --removing               Removing orphan configs or secrets
   -h, --help                   display help for command
 ```
 

--- a/bin/oprah
+++ b/bin/oprah
@@ -23,8 +23,8 @@ program
   )
   .option('-i, --interactive', 'Run on interactive mode')
   .option('-m, --missing', 'Only prompt missing values in interactive mode')
-  .option('-d, --deleting [deleting]', 'Deleting orphan configs or secrets')
-  .action(({ interactive, variables, missing, deleting = false }) => {
+  .option('-r, --removing [removing]', 'Removing orphan configs or secrets')
+  .action(({ interactive, variables, missing, removing = false }) => {
     let parsedVariables = {};
 
     try {
@@ -46,7 +46,7 @@ program
       variables: parsedVariables
     };
 
-    oprahPromise = makeOprah(params).run({ deleting });
+    oprahPromise = makeOprah(params).run({ removing });
   });
 
 program

--- a/bin/oprah
+++ b/bin/oprah
@@ -23,8 +23,8 @@ program
   )
   .option('-i, --interactive', 'Run on interactive mode')
   .option('-m, --missing', 'Only prompt missing values in interactive mode')
-  .option('-cu, --cleaning-up [cleanUp]', 'Clean up orphan configs or secrets')
-  .action(({ interactive, variables, missing, cleanUp = false }) => {
+  .option('-d, --deleting [deleting]', 'Deleting orphan configs or secrets')
+  .action(({ interactive, variables, missing, deleting = false }) => {
     let parsedVariables = {};
 
     try {
@@ -46,7 +46,7 @@ program
       variables: parsedVariables
     };
 
-    oprahPromise = makeOprah(params).run({ deleting: cleanUp });
+    oprahPromise = makeOprah(params).run({ deleting });
   });
 
 program

--- a/lib/commands/run/make-run.js
+++ b/lib/commands/run/make-run.js
@@ -1,8 +1,8 @@
 const makeRun = ({ init, configure, cleanUp }) => (
-  { deleting } = { deleting: false }
+  { removing } = { removing: false }
 ) =>
   init()
     .then(configure)
-    .then(() => deleting && cleanUp());
+    .then(() => removing && cleanUp());
 
 module.exports = { makeRun };

--- a/lib/commands/run/make-run.test.js
+++ b/lib/commands/run/make-run.test.js
@@ -15,15 +15,15 @@ describe('#makeRun', () => {
     jest.clearAllMocks();
   });
 
-  it('should call init, configuration but not cleanUp if deleting is not required', () =>
-    run({ deleting: false }).then(() => {
+  it('should call init, configuration but not cleanUp if removing is not required', () =>
+    run({ removing: false }).then(() => {
       expect(mockInit).toHaveBeenCalledTimes(1);
       expect(mockConfigure).toHaveBeenCalledTimes(1);
       expect(mockCleanUp).not.toHaveBeenCalled();
     }));
 
-  it('should call init, configuration and cleanUp if deleting is required', () =>
-    run({ deleting: true }).then(() => {
+  it('should call init, configuration and cleanUp if removing is required', () =>
+    run({ removing: true }).then(() => {
       expect(mockInit).toHaveBeenCalledTimes(1);
       expect(mockConfigure).toHaveBeenCalledTimes(1);
       expect(mockCleanUp).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## What did you implement:

`run` command now supports `-d, --deleting` option to delete orphan configurations or secrets

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources

