### PR TITLE
Fixed: provider specification in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ $ npm install oprah
 
 ```
 service: oprah-service
-provider: ssm
+provider:
+  name: ssm
 
 config:
   path: /${stage}/oprah/config
@@ -52,7 +53,8 @@ Following is the configuration file will all possible options:
 
 ```
 service: oprah-service
-provider: ssm                                 # Only supports ssm for now.
+provider:
+  name: ssm                                   # Only supports ssm for now.
 
 stacks:                                       # Outputs from cloudformation stacks that needs to be interpolated.
   - some-cloudformation-stack


### PR DESCRIPTION
## What did you implement:

This PR updates the example `provider` settings in the project README to use `provider.name`. Oprah expects `provider.name` to be specified, not just `provider`.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Updated the README

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Copy/paste the example config from the README into an `oprah.yml` then run `oprah init`. You should be able to do so without error.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Provide verification config/commands/resources

