### PR TITLE
chore: bump version to 5.4.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v5.4.0](2022-07-06)
+### Fixed
+- region is no longer hard coded to `us-east-1` (thanks @Danwakeem)
+- updated documentation to reflect changes to `provider.name` sturcture (thanks @tnation14)
+
 ## [v5.3.1](2022-05-16)
 ### Fixed
 - using `-m` when there's no missing secrets doesn't crash anymore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oprah",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "Package to deploy parameters to AWS",
   "repository": "https://github.com/ACloudGuru/oprah.git",
   "author": "subash adhikari <subash.adhikari@acloud.guru>",


### PR DESCRIPTION
## What did you implement:

Small release getting ready for a version 5.4.0 release that will incorporate #172 and #175:

* Bump version
* Add change log