### PR TITLE
feat: generate command

### DIFF
--- a/bin/oprah
+++ b/bin/oprah
@@ -59,6 +59,15 @@ program
   });
 
 program
+  .command('generate')
+  .description('Generate an example configuration file.')
+  .action(() => {
+    const { stage, config } = program.opts();
+
+    oprahPromise = makeOprah({ stage, config }).generate();
+  });
+
+program
   .command('export')
   .description(
     'Export of all of the configuration from the provider to a text json file'
@@ -146,7 +155,7 @@ if (!process.argv.slice(2).length) {
   displayHelpAndExit();
 }
 
-if (!program.opts().stage) {
+if (program.args[0] !== 'generate' && !program.opts().stage) {
   logError('Invalid options!! You must specify stage.');
   displayHelpAndExit();
 }

--- a/lib/commands/generate/make-generate.js
+++ b/lib/commands/generate/make-generate.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-template-curly-in-string */
+const { writeFile, existsSync } = require('fs');
+const { dump } = require('js-yaml');
+
+const defaultConfig = {
+  service: 'my-service',
+  provider: {
+    name: 'ssm'
+  },
+  config: {
+    path: '/${stage}/config',
+    defaults: {
+      DB_NAME: 'my-database',
+      DB_HOST: 3200
+    },
+    required: {
+      DB_TABLE: 'some database table name for ${stage}'
+    }
+  },
+  secret: {
+    path: '/${stage}/secret',
+    required: {
+      DB_PASSWORD: 'secret database password'
+    }
+  }
+};
+
+const makeGenerate = () => async () => {
+  if (existsSync('oprah.yml')) {
+    throw new Error(
+      `oprah.yml file already exists in the following directory -- ${process.cwd()}`
+    );
+  }
+
+  writeFile('oprah.yml', dump(defaultConfig), () => {});
+};
+
+module.exports = {
+  defaultConfig,
+  makeGenerate
+};

--- a/lib/commands/generate/make-generate.test.js
+++ b/lib/commands/generate/make-generate.test.js
@@ -1,0 +1,36 @@
+const { dump } = require('js-yaml');
+
+const mockWriteFile = jest.fn();
+const mockExists = jest.fn();
+
+jest.mock('fs', () => ({
+  writeFile: mockWriteFile,
+  existsSync: mockExists
+}));
+
+const { makeGenerate, defaultConfig } = require('./make-generate');
+
+describe('make generate', () => {
+  describe('when file exists', () => {
+    it('throws an error', async () => {
+      mockExists.mockReturnValueOnce(true);
+      const generate = makeGenerate();
+      await expect(generate).rejects.toThrow(
+        `oprah.yml file already exists in the following directory -- ${process.cwd()}`
+      );
+    });
+  });
+
+  describe('when file doesnt exist', () => {
+    it('generates file', async () => {
+      mockExists.mockReturnValueOnce(false);
+      const generate = makeGenerate();
+      await generate();
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        'oprah.yml',
+        dump(defaultConfig),
+        expect.any(Function)
+      );
+    });
+  });
+});

--- a/lib/make-oprah.js
+++ b/lib/make-oprah.js
@@ -16,6 +16,7 @@ const { makeFetch } = require('./commands/fetch/make-fetch');
 const { makeInit } = require('./commands/init/make-init');
 const { makeConfigure } = require('./commands/configure/make-configure');
 const { makeCleanup } = require('./commands/cleanup/make-cleanup');
+const { makeGenerate } = require('./commands/generate/make-generate');
 
 const makeOprah = ({
   stage,
@@ -57,6 +58,7 @@ const makeOprah = ({
   return {
     configure,
     init,
+    generate: makeGenerate(),
     run: makeRun({ init, configure, cleanUp }),
     list: makeList({ settingsService, parameterStore }),
     export: makeExport({ settingsService, parameterStore }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oprah",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "Package to deploy parameters to AWS",
   "repository": "https://github.com/ACloudGuru/oprah.git",
   "author": "subash adhikari <subash.adhikari@acloud.guru>",


### PR DESCRIPTION
## What did you implement:

* Implemented a new command that will generate a sample configuration file to get started.

## How did you implement it:

* Added command file
* added generate command logic
* made it so stage arg is not required for generate command

## How can we verify it:

Verify if no oprah yml extists one is generated
```
`./bin/oprah generate
```

Verify if one does exists an error occurs
```
`./bin/oprah generate
```
<img width="1358" alt="Screen Shot 2022-10-06 at 2 06 30 PM" src="https://user-images.githubusercontent.com/37553025/194418652-9143502a-8d9f-4545-b8a3-0b07fa61a5b0.png">

