### PR TITLE
feat: add multi-region support

### DIFF
--- a/lib/services/cf/get-outputs.js
+++ b/lib/services/cf/get-outputs.js
@@ -1,10 +1,9 @@
 const get = require('lodash/get');
 const AWS = require('aws-sdk');
-
-AWS.config.update({ region: 'us-east-1' });
-
-const cloudformation = new AWS.CloudFormation();
 const chalk = require('chalk');
+const { getRegion } = require('../settings/get-region');
+
+const cloudformation = new AWS.CloudFormation({ region: getRegion() });
 const { log, logWarning } = require('../../utils/logger');
 
 const readCfOutputs = async ({ stackName }) => {

--- a/lib/services/parameter-store/stores/ssm/get-ssm-client.js
+++ b/lib/services/parameter-store/stores/ssm/get-ssm-client.js
@@ -1,8 +1,7 @@
 const AWS = require('aws-sdk');
+const { getRegion } = require('../../../settings/get-region');
 
-AWS.config.update({ region: 'us-east-1' });
-
-const ssm = new AWS.SSM();
+const ssm = new AWS.SSM({ region: getRegion() });
 
 module.exports = {
   getSsmClient: () => ssm

--- a/lib/services/settings/get-account-id.js
+++ b/lib/services/settings/get-account-id.js
@@ -1,9 +1,8 @@
 const AWS = require('aws-sdk');
 const get = require('lodash/get');
+const { getRegion } = require('./get-region');
 
-AWS.config.update({ region: 'us-east-1' });
-
-const sts = new AWS.STS();
+const sts = new AWS.STS({ region: getRegion() });
 
 const getAccountId = () =>
   sts

--- a/lib/services/settings/get-region.js
+++ b/lib/services/settings/get-region.js
@@ -1,4 +1,5 @@
-const getRegion = () => 'us-east-1';
+const getRegion = () =>
+  process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1';
 
 module.exports = {
   getRegion

--- a/lib/services/settings/get-region.test.js
+++ b/lib/services/settings/get-region.test.js
@@ -1,0 +1,35 @@
+const { getRegion } = require('./get-region');
+
+describe('getRegion', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_DEFAULT_REGION;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should default to us-east-1 when no env vars set', () => {
+    expect(getRegion()).toEqual('us-east-1');
+  });
+
+  it('should use AWS_REGION when set', () => {
+    process.env.AWS_REGION = 'us-west-2';
+    expect(getRegion()).toEqual('us-west-2');
+  });
+
+  it('should use AWS_DEFAULT_REGION when AWS_REGION not set', () => {
+    process.env.AWS_DEFAULT_REGION = 'eu-west-1';
+    expect(getRegion()).toEqual('eu-west-1');
+  });
+
+  it('should prefer AWS_REGION over AWS_DEFAULT_REGION', () => {
+    process.env.AWS_REGION = 'ap-southeast-2';
+    process.env.AWS_DEFAULT_REGION = 'eu-west-1';
+    expect(getRegion()).toEqual('ap-southeast-2');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oprah",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "description": "Package to deploy parameters to AWS",
   "repository": "https://github.com/ACloudGuru/oprah.git",
   "author": "subash adhikari <subash.adhikari@acloud.guru>",


### PR DESCRIPTION
## What did you implement:

- Adds support for regions outside of `us-east-1` 

## How did you implement it:

- Enable an override for the hard-coded `us-east-1` entry in the `get-region` service
- Ensured the `get-region` service was used appropriately

## How can we verify it:

- Run test suite: `npx jest get-region get-outputs.test get-ssm-client.test get-account-id`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources

